### PR TITLE
fix: imprimir()

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
@@ -45,7 +45,7 @@ public class TicketMachine {
             throw new SaldoInsuficienteException();
         }
         String result = "*****************\n";
-        result += "*** R$ " + saldo + ",00 ****\n";
+        result += "*** R$ " + valor + ",00 ****\\n";
         result += "*****************\n";
         return result;
     }


### PR DESCRIPTION
No método imprimir, o valor exibido é o saldo, mas deveria ser o valor do ticket (valor), ou mostrar a diferença entre o saldo e o valor do ticket, indicando o troco.