### PR TITLE
Fix: While(valor)

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -13,7 +13,8 @@ class Troco {
     public Troco(int valor) {
         papeisMoeda = new PapelMoeda[6];
         int count = 0;
-        while (valor % 100 != 0) {
+        while (valor >= 100) {
+            valor -= 100;
             count++;
         }
         papeisMoeda[5] = new PapelMoeda(100, count);


### PR DESCRIPTION
No construtor Troco(int valor), os loops while (valor % x != 0) estão incorretos. Eles nunca modificarão o valor nem farão a contagem corretamente, pois o valor não está sendo alterado dentro do loop.