### PR TITLE
Fix: papeisMoeda[

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -42,7 +42,7 @@ class Troco {
         while (valor % 2 != 0) {
             count++;
         }
-        papeisMoeda[1] = new PapelMoeda(2, count);
+        papeisMoeda[0] = new PapelMoeda(2, count);
     }
 
     public Iterator<PapelMoeda> getIterator() {


### PR DESCRIPTION
 índice papeisMoeda[1] está sendo atribuído duas vezes (para as cédulas de 5 e 2 reais). A segunda atribuição deveria ser para papeisMoeda[0].