### PR TITLE
fix: adicionando mensagens de erro

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
@@ -27,7 +27,7 @@ public class TicketMachine {
             }
         }
         if (!achou) {
-            throw new PapelMoedaInvalidaException();
+            throw new PapelMoedaInvalidaException("Quantia inserida é inválida!");
         }
         this.saldo += quantia;
     }
@@ -42,7 +42,7 @@ public class TicketMachine {
 
     public String imprimir() throws SaldoInsuficienteException {
         if (saldo < valor) {
-            throw new SaldoInsuficienteException();
+            throw new SaldoInsuficienteException("Saldo insuficiente!");
         }
         String result = "*****************\n";
         result += "*** R$ " + valor + ",00 ****\\n";


### PR DESCRIPTION
As exceções PapelMoedaInvalidaException e SaldoInsuficienteException não fornecem mensagens de erro descritivas, o que poderia dificultar a depuração.