### PR TITLE
Fix: PapelMoeda

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -70,7 +70,7 @@ class Troco {
         @Override
         public PapelMoeda next() {
             PapelMoeda ret = null;
-            for (int i = 6; i >= 0 && ret != null; i++) {
+                for (int i = 5; i >= 0 && ret == null; i++) {
                 if (troco.papeisMoeda[i] != null) {
                     ret = troco.papeisMoeda[i];
                     troco.papeisMoeda[i] = null;


### PR DESCRIPTION
A classe TrocoIterator no arquivo Troco.java possui um erro no método next, onde a variável ret não é inicializada adequadamente, levando a um comportamento inesperado.