### PR TITLE
fix: remove()

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -81,7 +81,9 @@ class Troco {
 
         @Override
         public void remove() {
-            next();
+            if (hasNext()) {
+                next();
+            }
         }
     }
 }


### PR DESCRIPTION
O método remove não deveria simplesmente chamar next() sem verificar adequadamente se o próximo elemento existe.